### PR TITLE
Add links to GitHub security advisories

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ gh alerts [-h] [-o ORG_NAME] [PACKAGE_NAME]
 
 ## Examples
 ```bash
-gh alerts pyyaml
-PACKAGE  SEVERITY       MANIFEST
-pyyaml   high severity  requirements.txt
-pyyaml   high severity  requirements.txt
+gh alerts
+
+# glob-parent  high severity    package-lock.json    https://github.com/advisories/GHSA-ww39-953v-wcq6
+# braces       high severity    package-lock.json    https://github.com/advisories/GHSA-grv7-fg5c-xmjg
+# ws           high severity    package-lock.json    https://github.com/advisories/GHSA-3h5v-q93c-6h6q
 ```

--- a/gh-alerts
+++ b/gh-alerts
@@ -66,13 +66,13 @@ TEMPLATE="
   {{- range .data.repository.vulnerabilityAlerts.nodes -}}
     {{- if or (not \"${PACKAGE}\") (eq .securityVulnerability.package.name \"${PACKAGE}\") -}}
       {{- if eq .securityVulnerability.severity \"CRITICAL\" -}}
-        {{- tablerow .securityVulnerability.package.name (autocolor \"red\" \"critical severity\") .vulnerableManifestPath -}}
+        {{- tablerow .securityVulnerability.package.name (autocolor \"red\" \"critical severity\") .vulnerableManifestPath .securityAdvisory.permalink -}}
       {{- else if eq .securityVulnerability.severity \"HIGH\" -}}
-        {{- tablerow .securityVulnerability.package.name (autocolor \"magenta\" \"high severity\") .vulnerableManifestPath -}}
+        {{- tablerow .securityVulnerability.package.name (autocolor \"magenta\" \"high severity\") .vulnerableManifestPath .securityAdvisory.permalink -}}
       {{- else if eq .securityVulnerability.severity \"MODERATE\" -}}
-        {{- tablerow .securityVulnerability.package.name (autocolor \"yellow\" \"moderate severity\") .vulnerableManifestPath -}}
+        {{- tablerow .securityVulnerability.package.name (autocolor \"yellow\" \"moderate severity\") .vulnerableManifestPath .securityAdvisory.permalink -}}
       {{- else if eq .securityVulnerability.severity \"LOW\" -}}
-        {{- tablerow .securityVulnerability.package.name (autocolor \"cyan\" \"low severity\") .vulnerableManifestPath -}}
+        {{- tablerow .securityVulnerability.package.name (autocolor \"cyan\" \"low severity\") .vulnerableManifestPath .securityAdvisory.permalink -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
@@ -115,13 +115,13 @@ ORG_TEMPLATE="
     {{- range .vulnerabilityAlerts.nodes -}}
       {{- if or (not \"${PACKAGE}\") (eq .securityVulnerability.package.name \"${PACKAGE}\") -}}
         {{- if eq .securityVulnerability.severity \"CRITICAL\" -}}
-          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"red\" \"critical severity\") .vulnerableManifestPath -}}
+          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"red\" \"critical severity\") .securityAdvisory.permalink -}}
         {{- else if eq .securityVulnerability.severity \"HIGH\" -}}
-          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"magenta\" \"high severity\") .vulnerableManifestPath -}}
+          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"magenta\" \"high severity\") .securityAdvisory.permalink -}}
         {{- else if eq .securityVulnerability.severity \"MODERATE\" -}}
-          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"yellow\" \"moderate severity\") .vulnerableManifestPath -}}
+          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"yellow\" \"moderate severity\") .securityAdvisory.permalink -}}
         {{- else if eq .securityVulnerability.severity \"LOW\" -}}
-          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"cyan\" \"low severity\") .vulnerableManifestPath -}}
+          {{- tablerow .repository.nameWithOwner .securityVulnerability.package.name (autocolor \"cyan\" \"low severity\") .securityAdvisory.permalink -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
This comes in handy when your terminal supports clicking on links and opening them in the browser.