### PR TITLE
Update the help example with URLs in output

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ gh alerts [-h] [-o ORG_NAME] [PACKAGE_NAME]
 ```bash
 gh alerts
 
-# glob-parent  high severity    package-lock.json    https://github.com/advisories/GHSA-ww39-953v-wcq6
-# braces       high severity    package-lock.json    https://github.com/advisories/GHSA-grv7-fg5c-xmjg
-# ws           high severity    package-lock.json    https://github.com/advisories/GHSA-3h5v-q93c-6h6q
+glob-parent  high severity    package-lock.json    https://github.com/advisories/GHSA-ww39-953v-wcq6
+braces       high severity    package-lock.json    https://github.com/advisories/GHSA-grv7-fg5c-xmjg
+ws           high severity    package-lock.json    https://github.com/advisories/GHSA-3h5v-q93c-6h6q
 ```

--- a/gh-alerts
+++ b/gh-alerts
@@ -14,9 +14,10 @@ OPTIONS
 
 EXAMPLES
   $ gh alerts pyyaml
-  PACKAGE  SEVERITY       MANIFEST
-  pyyaml   high severity  requirements.txt
-  pyyaml   high severity  requirements.txt
+  PACKAGE      SEVERITY         MANIFEST             URL
+  glob-parent  high severity    package-lock.json    https://github.com/advisories/GHSA-ww39-953v-wcq6
+  braces       high severity    package-lock.json    https://github.com/advisories/GHSA-grv7-fg5c-xmjg
+  ws           high severity    package-lock.json    https://github.com/advisories/GHSA-3h5v-q93c-6h6q
 EOF
 }
 


### PR DESCRIPTION
The help output should also show URLs in the example now that links to the advisory are included.

This change also removes the unnecessary "#" characters in README for example output.