### PR TITLE
Nit fix to remove package in the example help

### DIFF
--- a/gh-alerts
+++ b/gh-alerts
@@ -13,7 +13,7 @@ OPTIONS
   -h, --help                    show this help message and exit
 
 EXAMPLES
-  $ gh alerts pyyaml
+  $ gh alerts
   PACKAGE      SEVERITY         MANIFEST             URL
   glob-parent  high severity    package-lock.json    https://github.com/advisories/GHSA-ww39-953v-wcq6
   braces       high severity    package-lock.json    https://github.com/advisories/GHSA-grv7-fg5c-xmjg


### PR DESCRIPTION
The help output includes an example passing a package name. However it gives a Python package and the output shows nodejs advisories.

This change removes that mismatch.